### PR TITLE
Fix highlight issue with mission "Seize the Italian Islands"

### DIFF
--- a/missions/Italian_Missions.txt
+++ b/missions/Italian_Missions.txt
@@ -1120,7 +1120,7 @@ Italian_missions_3 = {
 		position = 3
 		provinces_to_highlight = {
             OR = {
-                area = calabria_area
+                area = sicily_area
 				area = corsica_sardinia_area
             }
             NOT = {


### PR DESCRIPTION
Fixes the "Seize the Italian Islands" mission to properly highlight the area of Sicily instead of the area of Calabria. 